### PR TITLE
Integrate Claude API for Chat Backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+poetry.lock

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,110 @@
+from fastapi import FastAPI, HTTPException, Depends
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from typing import List, Optional
+import anthropic
+import os
+from dotenv import load_dotenv
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from datetime import datetime, timedelta
+import json
+
+load_dotenv()
+
+app = FastAPI()
+
+# CORS設定
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# ボット設定
+BOTS = {
+    "schedule": {
+        "id": "schedule",
+        "name": "日程調整Bot",
+        "description": "日程調整を手伝います",
+        "system_prompt": "あなたは日程調整の専門家です。ユーザーの日程調整を手伝ってください。",
+    },
+    "research": {
+        "id": "research",
+        "name": "リサーチBot",
+        "description": "調査研究を支援します",
+        "system_prompt": "あなたは研究調査の専門家です。ユーザーの調査を手伝ってください。",
+    }
+}
+
+# Google Calendar API設定
+SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
+credentials = None
+
+class Message(BaseModel):
+    role: str
+    content: str
+
+class ChatRequest(BaseModel):
+    messages: List[Message]
+
+@app.get("/bots")
+async def get_bots():
+    return list(BOTS.values())
+
+@app.get("/bots/{bot_id}")
+async def get_bot(bot_id: str):
+    if bot_id not in BOTS:
+        raise HTTPException(status_code=404, detail="Bot not found")
+    return BOTS[bot_id]
+
+@app.post("/chat/{bot_id}")
+async def chat(bot_id: str, request: ChatRequest):
+    if bot_id not in BOTS:
+        raise HTTPException(status_code=404, detail="Bot not found")
+    
+    try:
+        client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+        
+        # システムプロンプトとユーザーメッセージを結合
+        messages = [
+            {"role": "system", "content": BOTS[bot_id]["system_prompt"]},
+            *request.messages
+        ]
+        
+        # Claude APIを使用してレスポンスを生成
+        response = client.messages.create(
+            model="claude-3-opus-20240229",
+            max_tokens=1000,
+            messages=messages,
+            stream=True
+        )
+        
+        return response
+        
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/auth/google")
+async def google_auth():
+    flow = InstalledAppFlow.from_client_config(
+        {
+            "installed": {
+                "client_id": os.getenv("GOOGLE_CLIENT_ID"),
+                "client_secret": os.getenv("GOOGLE_CLIENT_SECRET"),
+                "redirect_uris": ["urn:ietf:wg:oauth:2.0:oob"],
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token"
+            }
+        },
+        SCOPES
+    )
+    auth_url = flow.authorization_url()
+    return {"auth_url": auth_url[0]}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "backend_app"
+version = "0.1.0"
+description = "Multi-bot Chat Backend API"
+authors = ["Devin <devin@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "^0.109.0"
+uvicorn = "^0.27.0"
+pydantic = "^2.5.3"
+openai = "^1.10.0"
+python-dotenv = "^1.0.0"
+fastapi-cli = "^0.0.7"
+anthropic = "^0.7.1"
+google-auth-oauthlib = "^1.2.0"
+google-auth-httplib2 = "^0.2.0"
+google-api-python-client = "^2.118.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
# Claude API Integration for Chat Backend

This PR implements the backend for a multi-bot chat application using FastAPI and integrates with Anthropic's Claude API.

## Changes
- Add FastAPI backend with Claude API integration
- Implement calendar integration endpoints
- Add streaming chat responses
- Configure environment variables and .gitignore

## Testing
- [ ] Backend implementation needs to be tested with the frontend
- [ ] Google Calendar integration needs to be tested with valid credentials

Link to Devin run: https://app.devin.ai/sessions/3ca84ea76fc4418cbd827063b8a10263
