### PR TITLE
Fix static export to support /chat/schedule route

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,45 @@
+let userConfig = undefined
+try {
+  userConfig = await import('./v0-user-next.config')
+} catch (e) {
+  // ignore error
+}
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+  output: 'export',
+  distDir: 'dist',
+  images: {
+    unoptimized: true
+  }
+}
+
+mergeConfig(nextConfig, userConfig)
+
+function mergeConfig(nextConfig, userConfig) {
+  if (!userConfig) {
+    return
+  }
+
+  for (const key in userConfig) {
+    if (
+      typeof nextConfig[key] === 'object' &&
+      !Array.isArray(nextConfig[key])
+    ) {
+      nextConfig[key] = {
+        ...nextConfig[key],
+        ...userConfig[key],
+      }
+    } else {
+      nextConfig[key] = userConfig[key]
+    }
+  }
+}
+
+export default nextConfig


### PR DESCRIPTION
静的エクスポートの設定を修正し、/chat/scheduleルートのサポートを追加しました。

変更内容:
- next.config.mjsの設定を簡素化
- 不要なroutingオプションを削除
- 静的エクスポートの設定を最適化

Link to Devin run: https://app.devin.ai/sessions/3ca84ea76fc4418cbd827063b8a10263