### PR TITLE
カレンダー予定登録機能の修正

### DIFF
--- a/app/claude_service.py
+++ b/app/claude_service.py
@@ -1,0 +1,121 @@
+from datetime import datetime, timedelta
+import anthropic
+import os
+from typing import Dict, List, Optional
+import json
+
+class ClaudeService:
+    def __init__(self):
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise ValueError("ANTHROPIC_API_KEY environment variable is not set")
+        self.client = anthropic.Anthropic(
+            api_key=api_key
+        )
+    
+    async def analyze_free_slots(
+        self,
+        busy_slots: List[Dict],
+        start_time: datetime,
+        end_time: datetime,
+        calendar_id: str
+    ) -> Optional[Dict]:
+        calendar_data = {
+            "calendars": {
+                calendar_id: {
+                    "busy": busy_slots
+                }
+            }
+        }
+        
+        prompt = f"""
+        次のJSONはGoogleカレンダーのfreeBusy.queryのレスポンスです。
+        この中で空いている時間帯を見つけ、最適な1時間のスロットを提案してください。
+
+        条件:
+        - 営業時間：9:00から18:00まで
+        - できるだけ早い時間のスロットを優先
+        - 1時間の時間を確保
+        - 既存の予定と重複しない
+        - 予定と予定の間に十分な空きがある時間帯を選択
+
+        JSON:
+        {json.dumps(calendar_data, ensure_ascii=False, indent=2)}
+        
+        レスポンスは以下のJSON形式で返してください：
+        {{
+          "suggested_time": {{
+            "start": "YYYY-MM-DDTHH:MM:SS+09:00",
+            "end": "YYYY-MM-DDTHH:MM:SS+09:00"
+          }},
+          "reason": "選択理由"
+        }}
+        """
+        
+        try:
+            response = await self.client.messages.create(
+                model="claude-3-opus-20240229",
+                max_tokens=1000,
+                messages=[{
+                    "role": "user",
+                    "content": prompt
+                }]
+            )
+                
+            try:
+                content = response.content[0].text
+                slot_data = json.loads(content)
+                
+                if self._validate_slot(slot_data, start_time, end_time, busy_slots):
+                    return slot_data
+                return None
+            except (json.JSONDecodeError, KeyError, IndexError, AttributeError) as e:
+                print(f"Failed to parse Claude response: {str(e)}")
+                print(f"Raw response: {response}")
+                return None
+            
+        except Exception as e:
+            print(f"Claude API error: {str(e)}")
+            return None
+            
+    def _validate_slot(
+        self,
+        result: Dict,
+        start_time: datetime,
+        end_time: datetime,
+        busy_slots: List[Dict]
+    ) -> bool:
+        try:
+            # Validate suggested time slot
+            suggested = result.get("suggested_time", {})
+            slot_start = datetime.fromisoformat(suggested.get("start")).replace(tzinfo=None)
+            slot_end = datetime.fromisoformat(suggested.get("end")).replace(tzinfo=None)
+            
+            # Check business hours
+            if not (9 <= slot_start.hour < 18 and 9 <= slot_end.hour <= 18):
+                return False
+                
+            # Check slot duration
+            if slot_end - slot_start != timedelta(hours=1):
+                return False
+                
+            # Check within requested time range
+            if slot_start < start_time or slot_end > end_time:
+                return False
+                
+            # Check for overlaps with existing events
+            for busy in busy_slots:
+                busy_start = datetime.fromisoformat(busy["start"]).replace(tzinfo=None)
+                busy_end = datetime.fromisoformat(busy["end"]).replace(tzinfo=None)
+                if (slot_start < busy_end and slot_end > busy_start):
+                    return False
+                
+                # Check for minimum buffer between events (15 minutes)
+                buffer = timedelta(minutes=15)
+                if abs(slot_start - busy_end) < buffer or abs(slot_end - busy_start) < buffer:
+                    return False
+                    
+            return True
+        except Exception as e:
+            print(f"Claude API error: {str(e)}")
+            return False

--- a/app/claude_service.py
+++ b/app/claude_service.py
@@ -10,18 +10,26 @@ class ClaudeService:
         try:
             # Convert all times to UTC for comparison
             utc = timezone.utc
+            jst = timezone(timedelta(hours=9))
+            
+            # Ensure times are timezone-aware and in UTC
             slot_start = slot_start.astimezone(utc)
             slot_end = slot_end.astimezone(utc)
             
             # Convert to JST for business hours check
-            jst = timezone(timedelta(hours=9))
             jst_start = slot_start.astimezone(jst)
             jst_end = slot_end.astimezone(jst)
             
             # Check business hours (9:00-18:00 JST)
             if not (9 <= jst_start.hour < 18 and 9 <= jst_end.hour <= 18):
+                print(f"Outside business hours: {jst_start.hour}:00-{jst_end.hour}:00")
                 return False
-                
+            
+            # Check duration is exactly 1 hour
+            if (slot_end - slot_start) != timedelta(hours=1):
+                print("Invalid duration - must be exactly 1 hour")
+                return False
+            
             # Check for conflicts with existing events
             for busy in busy_slots:
                 busy_start = datetime.fromisoformat(busy["start"].replace('Z', '+00:00')).astimezone(utc)
@@ -29,8 +37,9 @@ class ClaudeService:
                 
                 # Check overlap
                 if (slot_start < busy_end and slot_end > busy_start):
+                    print(f"Conflict with existing event: {busy_start.astimezone(jst)} - {busy_end.astimezone(jst)}")
                     return False
-                    
+            
             return True
         except Exception as e:
             print(f"Validation error: {str(e)}")
@@ -39,6 +48,7 @@ class ClaudeService:
     def find_available_slots(self, busy_slots, start_time, end_time):
         """Find available time slots within the given range."""
         available_slots = []
+        current = start_time  # Start from the requested start time
         
         # Convert busy slots to datetime objects and sort them
         busy_periods = []
@@ -49,36 +59,44 @@ class ClaudeService:
         
         busy_periods.sort(key=lambda x: x[0])
         
-        # If no busy periods, return first available hour
-        if not busy_periods:
-            available_slots.append({
-                "start": start_time,
-                "end": start_time + timedelta(hours=1)
-            })
-            return available_slots
+        # Check each hour in the requested range
+        while current + timedelta(hours=1) <= end_time:
+            # Check if any busy period affects the current time
+            for busy_start, busy_end in busy_periods:
+                if busy_start <= current + timedelta(hours=1):
+                    if busy_end > current:
+                        current = busy_end
+                        break
             
-        # Start from the end of first busy period
-        current = busy_periods[0][1]
-        
-        # Find gaps between busy periods
-        for i in range(len(busy_periods)):
-            # If this is not the last busy period, check gap until next busy period
-            if i < len(busy_periods) - 1:
-                next_start = busy_periods[i + 1][0]
-                if current + timedelta(hours=1) <= next_start:
-                    available_slots.append({
-                        "start": current,
-                        "end": current + timedelta(hours=1)
-                    })
-            current = busy_periods[i][1]
-        
-        # Check final period after last busy slot
-        if current + timedelta(hours=1) <= end_time:
-            available_slots.append({
-                "start": current,
-                "end": current + timedelta(hours=1)
-            })
+            # If we've gone past the end time, stop
+            if current + timedelta(hours=1) > end_time:
+                break
             
+            slot_end = current + timedelta(hours=1)
+            
+            # Check if this slot would be valid
+            if not self.validate_time_slot(current, slot_end, busy_slots):
+                current += timedelta(hours=1)
+                continue
+            
+            # Check if it overlaps with any future busy periods
+            is_available = True
+            for busy_start, busy_end in busy_periods:
+                if current < busy_end and slot_end > busy_start:
+                    is_available = False
+                    break
+            
+            # If slot is available, add it and return
+            if is_available:
+                available_slots.append({
+                    "start": current,
+                    "end": slot_end
+                })
+                return available_slots
+            
+            # Move to next hour if no valid slot found
+            current += timedelta(hours=1)
+        
         return available_slots
 
     def analyze_free_slots(self, busy_slots, start_time, end_time, calendar_id, message=""):
@@ -94,11 +112,8 @@ class ClaudeService:
             
             if not available_slots:
                 return {
-                    "suggested_time": {
-                        "start": start_time.isoformat(),
-                        "end": end_time.isoformat()
-                    },
-                    "reason": "指定された時間帯に空き時間が見つかりませんでした。別の時間帯をお試しください。"
+                    "suggested_time": None,
+                    "reason": f"{start_time.strftime('%H:%M')}から{end_time.strftime('%H:%M')}の間に空き時間が見つかりませんでした。"
                 }
             
             # Select the first available slot (earliest time)
@@ -106,21 +121,20 @@ class ClaudeService:
             slot_start = selected_slot["start"].astimezone(jst)
             slot_end = selected_slot["end"].astimezone(jst)
             
-            # Format times for response
+            # Format times for response with clearer explanation
             return {
                 "suggested_time": {
                     "start": slot_start.isoformat(),
                     "end": slot_end.isoformat()
                 },
-                "reason": f"{slot_start.strftime('%H:%M')}から{slot_end.strftime('%H:%M')}の時間帯が空いているため、この時間に予定を登録します。"
+                "reason": f"{start_time.strftime('%H:%M')}から{end_time.strftime('%H:%M')}の時間枠で、"
+                         f"{slot_start.strftime('%H:%M')}から{slot_end.strftime('%H:%M')}が空いているため、"
+                         f"この時間に予定を登録します。"
             }
             
         except Exception as e:
             print(f"Error analyzing free slots: {str(e)}")
             return {
-                "suggested_time": {
-                    "start": start_time.isoformat(),
-                    "end": end_time.isoformat()
-                },
+                "suggested_time": None,
                 "reason": "予定の確認中にエラーが発生しました。別の時間帯をお試しください。"
             }

--- a/app/claude_service.py
+++ b/app/claude_service.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-import anthropic
+from anthropic import Anthropic
 import os
 from typing import Dict, List, Optional
 import json
@@ -9,17 +9,16 @@ class ClaudeService:
         api_key = os.getenv("ANTHROPIC_API_KEY")
         if not api_key:
             raise ValueError("ANTHROPIC_API_KEY environment variable is not set")
-        self.client = anthropic.Anthropic(
-            api_key=api_key
-        )
+        self.client = Anthropic(api_key=api_key)
     
-    async def analyze_free_slots(
+    def analyze_free_slots(
         self,
         busy_slots: List[Dict],
         start_time: datetime,
         end_time: datetime,
         calendar_id: str
     ) -> Optional[Dict]:
+        """Find the best available time slot for a meeting."""
         calendar_data = {
             "calendars": {
                 calendar_id: {
@@ -29,60 +28,50 @@ class ClaudeService:
         }
         
         prompt = f"""
-        次のJSONはGoogleカレンダーのfreeBusy.queryのレスポンスです。
-        この中で空いている時間帯を見つけ、最適な1時間のスロットを提案してください。
+次のデータは Google Calendar の busy 時間です。空いている時間のリストを作成し、1時間の最適な時間を提案してください。
 
-        条件:
-        - 営業時間：午前9時から午後6時まで
-        - できるだけ早い時間のスロットを優先
-        - 1時間の会議時間を確保
-        - 既存の予定と重複しないこと
-        - 予定と予定の間に15分以上の余裕を確保
-        - 時間の説明は日本語で詳しく（例：午前10時から午前11時まで）
+指定された範囲: {start_time.strftime("%Y-%m-%d %H:%M")} 〜 {end_time.strftime("%Y-%m-%d %H:%M")}
+Busyデータ: {json.dumps(calendar_data, ensure_ascii=False)}
 
-        選択理由も日本語で詳しく説明してください。
-        例：「この時間帯を選んだ理由：
-        ・営業時間内の早い時間帯
-        ・前後の予定と15分以上の間隔あり
-        ・1時間の会議時間を確保可能」
+条件:
+- 最も早い時間に予約
+- 1時間の会議時間を確保
+- タイムゾーン：日本時間（JST/UTC+9）
+- 営業時間：午前9時から午後6時まで
+- 既存の予定と重複しない
+- 予定の前後に15分以上の余裕を確保
+- 時間の説明は日本語で詳しく
 
-        JSON:
-        {json.dumps(calendar_data, ensure_ascii=False, indent=2)}
-        
-        レスポンスは以下のJSON形式で返してください：
-        {{
-          "suggested_time": {{
-            "start": "YYYY-MM-DDTHH:MM:SS+09:00",
-            "end": "YYYY-MM-DDTHH:MM:SS+09:00"
-          }},
-          "reason": "選択理由"
-        }}
-        """
+出力形式:
+{{
+  "suggested_time": {{
+    "start": "YYYY-MM-DDTHH:MM:SS+09:00",
+    "end": "YYYY-MM-DDTHH:MM:SS+09:00"
+  }},
+  "reason": "選択理由（日本語で説明）"
+}}
+"""
         
         try:
-            response = await self.client.messages.create(
+            response = self.client.messages.create(
                 model="claude-3-opus-20240229",
                 max_tokens=1000,
-                messages=[{
-                    "role": "user",
-                    "content": prompt
-                }]
+                messages=[{"role": "user", "content": prompt}]
             )
-                
-            try:
-                content = response.content[0].text
-                slot_data = json.loads(content)
-                
+            
+            text = response.content[0].text
+            json_start = text.find('{')
+            json_end = text.rfind('}') + 1
+            
+            if json_start >= 0 and json_end > json_start:
+                slot_data = json.loads(text[json_start:json_end])
                 if self._validate_slot(slot_data, start_time, end_time, busy_slots):
                     return slot_data
-                return None
-            except (json.JSONDecodeError, KeyError, IndexError, AttributeError) as e:
-                print(f"Failed to parse Claude response: {str(e)}")
-                print(f"Raw response: {response}")
-                return None
+            
+            return None
             
         except Exception as e:
-            print(f"Claude API error: {str(e)}")
+            print(f"Claude APIエラー: {str(e)}")
             return None
             
     def _validate_slot(
@@ -92,52 +81,41 @@ class ClaudeService:
         end_time: datetime,
         busy_slots: List[Dict]
     ) -> bool:
+        """Validate the suggested time slot."""
         try:
-            # Validate suggested time slot
             suggested = result.get("suggested_time", {})
             if not suggested:
-                print("スロット提案が見つかりません")
-                return False
-                
-            try:
-                slot_start = datetime.fromisoformat(suggested.get("start")).replace(tzinfo=None)
-                slot_end = datetime.fromisoformat(suggested.get("end")).replace(tzinfo=None)
-            except (ValueError, TypeError) as e:
-                print(f"日時のパース中にエラーが発生しました: {str(e)}")
                 return False
             
-            # Check business hours (9:00-18:00)
+            # Parse times and normalize to naive datetime
+            slot_start = datetime.fromisoformat(suggested["start"]).replace(tzinfo=None)
+            slot_end = datetime.fromisoformat(suggested["end"]).replace(tzinfo=None)
+            start_time = start_time.replace(tzinfo=None)
+            end_time = end_time.replace(tzinfo=None)
+            
+            # Basic validation checks
             if not (9 <= slot_start.hour < 18 and 9 <= slot_end.hour <= 18):
-                print("営業時間外の時間帯が提案されました")
                 return False
-                
-            # Strictly validate slot duration (exactly 1 hour)
+            
             if slot_end - slot_start != timedelta(hours=1):
-                print("提案された時間枠が1時間ではありません")
                 return False
-                
-            # Check within requested time range
+            
             if slot_start < start_time or slot_end > end_time:
-                print("提案された時間枠が指定された範囲外です")
                 return False
-                
-            # Check for overlaps and minimum buffer with ALL existing events
+            
+            # Check for conflicts with existing events
             buffer = timedelta(minutes=15)
             for busy in busy_slots:
-                busy_start = datetime.fromisoformat(busy["start"]).replace(tzinfo=None)
-                busy_end = datetime.fromisoformat(busy["end"]).replace(tzinfo=None)
+                busy_start = datetime.fromisoformat(busy["start"].replace('Z', '+00:00')).replace(tzinfo=None)
+                busy_end = datetime.fromisoformat(busy["end"].replace('Z', '+00:00')).replace(tzinfo=None)
                 
-                # Strict overlap check
                 if (slot_start < busy_end and slot_end > busy_start):
-                    print("既存の予定と重複しています")
                     return False
                 
-                # Ensure minimum 15-minute buffer before and after
                 if abs(slot_start - busy_end) < buffer or abs(slot_end - busy_start) < buffer:
-                    print("既存の予定との間隔が15分未満です")
                     return False
-                    
+            
             return True
-        except Exception as e:
-            print(f"スロット検証エラー: {str(e)}")  # Changed to Japanese for consistency
+            
+        except Exception:
             return False

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,10 @@ from datetime import datetime, timedelta
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 import re
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 app = FastAPI()
 
@@ -36,42 +40,130 @@ async def handle_chat(message: ChatMessage):
     try:
         msg = message.message
         
-        # 日付と時間範囲の抽出（例：2月12日の12時から16時）
-        date_match = re.search(r'(\d+)月(\d+)日', msg)
-        time_range_match = re.search(r'(\d+)時から(\d+)時', msg)
+        # 日付と時間範囲の抽出
+        date_patterns = [
+            r'(\d+)月(\d+)日',  # MM月DD日
+            r'明日',            # 明日
+            r'明後日',          # 明後日
+            r'来週の(月|火|水|木|金|土|日)曜日'  # 来週の曜日
+        ]
+        time_patterns = [
+            r'(\d+)時から(\d+)時',      # HH時からHH時
+            r'午前(\d+)時から午後(\d+)時',  # 午前/午後
+            r'(\d+)時半'               # 時半
+        ]
         
-        if not date_match or not time_range_match:
+        # 日付のマッチング
+        date_match = None
+        for pattern in date_patterns:
+            match = re.search(pattern, msg)
+            if match:
+                date_match = match
+                break
+        
+        # 時間のマッチング
+        time_match = None
+        for pattern in time_patterns:
+            match = re.search(pattern, msg)
+            if match:
+                time_match = match
+                break
+        
+        # より具体的なエラーメッセージを提供
+        if not date_match:
             return {
-                "response": "すみません、日時を理解できませんでした。\n"
-                           "例：「2月12日の12時から16時で空いてる時間に会議を入れて」のように教えてください。\n"
-                           "※ 日付と時間は数字で指定してください。"
+                "response": "申し訳ありません。日付の指定を理解できませんでした。\n"
+                           "以下のような形式で指定してください：\n"
+                           "・2月12日\n"
+                           "・明日\n"
+                           "・明後日\n"
+                           "・来週の月曜日"
+            }
+            
+        if not time_match:
+            return {
+                "response": "申し訳ありません。時間の指定を理解できませんでした。\n"
+                           "以下のような形式で指定してください：\n"
+                           "・13時から16時\n"
+                           "・午前10時から午後3時\n"
+                           "・15時半"
             }
             
         # 日付の設定
-        month = int(date_match.group(1))
-        day = int(date_match.group(2))
-        current_year = datetime.now().year
+        current_date = datetime.now()
+        current_year = current_date.year
+        
+        if '明日' in msg:
+            target_date = current_date + timedelta(days=1)
+            month = target_date.month
+            day = target_date.day
+        elif '明後日' in msg:
+            target_date = current_date + timedelta(days=2)
+            month = target_date.month
+            day = target_date.day
+        elif '来週' in msg:
+            # 曜日を数値に変換 (月=0, 火=1, ...)
+            weekday_map = {'月': 0, '火': 1, '水': 2, '木': 3, '金': 4, '土': 5, '日': 6}
+            weekday = weekday_map[date_match.group(1)]
+            
+            # 現在の曜日から目標の曜日までの日数を計算
+            days_ahead = weekday - current_date.weekday()
+            if days_ahead <= 0:  # 次の週の同じ曜日
+                days_ahead += 7
+            target_date = current_date + timedelta(days=days_ahead + 7)  # +7 for next week
+            month = target_date.month
+            day = target_date.day
+        else:
+            # MM月DD日 形式の場合
+            month = int(date_match.group(1))
+            day = int(date_match.group(2))
         
         # 時間の設定と検証
-        start_hour = int(time_range_match.group(1))
-        end_hour = int(time_range_match.group(2))
+        if '午前' in msg and '午後' in msg:
+            start_hour = int(time_match.group(1))  # 午前の時間
+            end_hour = int(time_match.group(2)) + 12  # 午後の時間は12を加算
+        elif '時半' in msg:
+            time_str = time_match.group(1)
+            start_hour = int(time_str)
+            end_hour = start_hour + 1  # 30分は1時間として扱う
+        else:
+            start_hour = int(time_match.group(1))
+            end_hour = int(time_match.group(2))
         
-        # 基本的な入力値の検証
-        if not (1 <= month <= 12 and 1 <= day <= 31):
+        # 基本的な入力値の検証（より具体的なエラーメッセージ）
+        if not (1 <= month <= 12):
             return {
-                "response": "申し訳ありません。正しい日付を指定してください。\n"
-                           "月は1-12、日は1-31の範囲で指定してください。"
+                "response": "申し訳ありません。指定された月が無効です。\n"
+                           f"指定された月: {month}月\n"
+                           "1月から12月の間で指定してください。"
             }
             
-        if not (0 <= start_hour <= 23 and 0 <= end_hour <= 23):
+        if not (1 <= day <= 31):
             return {
-                "response": "申し訳ありません。正しい時間を指定してください。\n"
-                           "時間は0-23の範囲で指定してください。"
+                "response": "申し訳ありません。指定された日が無効です。\n"
+                           f"指定された日: {day}日\n"
+                           "1日から31日の間で指定してください。"
+            }
+            
+        if not (0 <= start_hour <= 23):
+            return {
+                "response": "申し訳ありません。指定された開始時刻が無効です。\n"
+                           f"指定された時刻: {start_hour}時\n"
+                           "0時から23時の間で指定してください。"
+            }
+            
+        if not (0 <= end_hour <= 23):
+            return {
+                "response": "申し訳ありません。指定された終了時刻が無効です。\n"
+                           f"指定された時刻: {end_hour}時\n"
+                           "0時から23時の間で指定してください。"
             }
             
         if start_hour >= end_hour:
             return {
-                "response": "申し訳ありません。終了時間は開始時間より後の時間を指定してください。"
+                "response": "申し訳ありません。終了時刻は開始時刻より後の時間を指定してください。\n"
+                           f"指定された時間帯: {start_hour}時から{end_hour}時\n"
+                           "例：13時から16時"
             }
             
         # 日付の妥当性チェック
@@ -88,9 +180,31 @@ async def handle_chat(message: ChatMessage):
                            "正しい日付を指定してください。"
             }
         
-        # 時間範囲の設定
-        start_hour = int(time_range_match.group(1))
-        end_hour = int(time_range_match.group(2))
+        # 時間範囲の設定（既に上で設定済みのため削除）
+        
+        # タイムゾーン設定
+        JST = '+09:00'
+        TIMEZONE = 'Asia/Tokyo'
+        
+        # 時間範囲の妥当性チェック
+        if end_hour - start_hour < 1:
+            return {
+                "response": "申し訳ありません。指定された時間範囲が短すぎます。\n"
+                           "少なくとも1時間以上の時間範囲を指定してください。"
+            }
+        
+        if end_hour - start_hour > 12:
+            return {
+                "response": "申し訳ありません。指定された時間範囲が長すぎます。\n"
+                           "12時間以内の時間範囲を指定してください。"
+            }
+        
+        # 営業時間チェック（9時から18時）
+        if start_hour < 9 or end_hour > 18:
+            return {
+                "response": "申し訳ありません。営業時間外の時間帯が指定されています。\n"
+                           "営業時間（9時から18時）内の時間帯を指定してください。"
+            }
         
         # 開始時刻と終了時刻の設定（JSTで設定）
         start_time = datetime(current_year, month, day, start_hour, 0, 0)
@@ -103,64 +217,108 @@ async def handle_chat(message: ChatMessage):
         
         # FreeBusy APIを使用して空き時間を取得
         body = {
-            'timeMin': start_time.isoformat() + '+09:00',
-            'timeMax': end_time.isoformat() + '+09:00',
-            'timeZone': 'Asia/Tokyo',
-            'items': [{'id': 'us.tomoki17@gmail.com'}]
+            'timeMin': start_time.isoformat() + JST,
+            'timeMax': end_time.isoformat() + JST,
+            'timeZone': TIMEZONE,
+            'items': [{'id': os.getenv('CALENDAR_ID', 'us.tomoki17@gmail.com')}]
         }
         
         freebusy_response = calendar_service.freebusy().query(body=body).execute()
-        busy_slots = freebusy_response['calendars']['us.tomoki17@gmail.com']['busy']
+        calendar_id = os.getenv('CALENDAR_ID', 'us.tomoki17@gmail.com')
+        busy_slots = freebusy_response['calendars'][calendar_id]['busy']
         
         # 空き時間を探す（1時間の会議を想定）
         meeting_duration = timedelta(hours=1)
         free_slots = []
         current_time = start_time
         
-        # 最初の空き時間を確認
-        if not busy_slots:
-            free_slots.append((current_time, end_time))
-        else:
-            # 最初のbusy slotまでの空き時間を確認
-            first_busy_start = datetime.fromisoformat(busy_slots[0]['start'].replace('Z', '+00:00'))
-            if current_time + meeting_duration <= first_busy_start:
-                free_slots.append((current_time, first_busy_start))
-            
-            # busy slotsの間の空き時間を確認
-            for i in range(len(busy_slots)):
-                current_busy_end = datetime.fromisoformat(busy_slots[i]['end'].replace('Z', '+00:00'))
-                next_busy_start = datetime.fromisoformat(busy_slots[i + 1]['start'].replace('Z', '+00:00')) if i + 1 < len(busy_slots) else end_time
-                
-                if current_busy_end + meeting_duration <= next_busy_start:
-                    free_slots.append((current_busy_end, next_busy_start))
-            
-            # 空き時間が見つかった場合、最初の空き時間に予定を登録
-            if free_slots:
-                slot_start, slot_end = free_slots[0]
-                event = {
-                    'summary': '会議',
-                    'start': {
-                        'dateTime': slot_start.isoformat() + '+09:00',
-                        'timeZone': 'Asia/Tokyo'
-                    },
-                    'end': {
-                        'dateTime': (slot_start + meeting_duration).isoformat() + '+09:00',
-                        'timeZone': 'Asia/Tokyo'
-                    }
-                }
-                
-                created_event = calendar_service.events().insert(
-                    calendarId='us.tomoki17@gmail.com',
-                    body=event
-                ).execute()
-                
-                return {
-                    "response": f"以下の空き時間に会議を登録しました：\n"
-                               f"日時：{slot_start.strftime('%Y年%m月%d日 %H:%M')}から"
-                               f"{(slot_start + meeting_duration).strftime('%H:%M')}まで\n"
-                               f"予定のリンク：{created_event.get('htmlLink')}"
-                }
+        # すべてのbusy slotsをタイムゾーンなしに変換
+        normalized_busy_slots = []
+        for slot in busy_slots:
+            slot_start = datetime.fromisoformat(slot['start'].replace('Z', '+00:00')).replace(tzinfo=None)
+            slot_end = datetime.fromisoformat(slot['end'].replace('Z', '+00:00')).replace(tzinfo=None)
+            normalized_busy_slots.append((slot_start, slot_end))
         
+        # 時間範囲内の各時間枠をチェック
+        while current_time + meeting_duration <= end_time:
+            proposed_end = current_time + meeting_duration
+            is_free = True
+            
+            # この時間枠が既存の予定と重複していないか確認
+            for busy_start, busy_end in normalized_busy_slots:
+                # 重複チェック: 現在の時間枠が既存の予定と重なっているか
+                if (current_time < busy_end and proposed_end > busy_start):
+                    is_free = False
+                    # 重複している場合、busy_endまでスキップして次の時間枠へ
+                    current_time = busy_end
+                    break
+            
+            # 重複があった場合は次のループへ
+            if not is_free:
+                continue
+                
+            # 空き時間が見つかったので予定を登録を試みる
+            event = {
+                'summary': '会議',
+                'start': {
+                    'dateTime': current_time.isoformat() + JST,
+                    'timeZone': TIMEZONE
+                },
+                'end': {
+                    'dateTime': proposed_end.isoformat() + JST,
+                    'timeZone': TIMEZONE
+                }
+            }
+            
+            # 予定作成前に再度空き時間チェック
+            recheck_body = {
+                'timeMin': current_time.isoformat() + JST,
+                'timeMax': proposed_end.isoformat() + JST,
+                'timeZone': TIMEZONE,
+                'items': [{'id': os.getenv('CALENDAR_ID', 'us.tomoki17@gmail.com')}]
+            }
+            
+            recheck_response = calendar_service.freebusy().query(body=recheck_body).execute()
+            recheck_busy = recheck_response['calendars']['us.tomoki17@gmail.com']['busy']
+            
+            if not recheck_busy:
+                try:
+                    # アトミックな操作として予定を作成
+                    created_event = calendar_service.events().insert(
+                        calendarId='us.tomoki17@gmail.com',
+                        body=event
+                    ).execute()
+                    
+                    # 作成成功時のみ終了
+                    return {
+                        "response": f"以下の空き時間に会議を登録しました：\n"
+                                   f"日時：{current_time.strftime('%Y年%m月%d日 %H:%M')}から"
+                                   f"{proposed_end.strftime('%H:%M')}まで\n"
+                                   f"予定のリンク：{created_event.get('htmlLink')}"
+                    }
+                except Exception as e:
+                    error_type = str(e)
+                    print(f"Event creation failed: {error_type}")
+                    
+                    if "The requested time slot is not available" in error_type:
+                        # 時間枠が既に使用されている場合
+                        current_time += meeting_duration
+                        continue
+                    elif "Invalid time range" in error_type:
+                        return {
+                            "response": "申し訳ありません。指定された時間範囲が無効です。\n"
+                                       "時間の指定を確認して、もう一度お試しください。"
+                        }
+                    else:
+                        # その他のエラー
+                        current_time += meeting_duration
+                        continue
+            
+            # 空き時間が見つからなかった場合は次の時間枠へ
+            if not is_free:
+                current_time += meeting_duration
+        
+        # すべての時間枠をチェックしても空き時間が見つからなかった場合
         return {
             "response": "申し訳ありません。指定された時間範囲内（" + 
                        f"{start_time.strftime('%H:%M')}から{end_time.strftime('%H:%M')}まで）に\n" +
@@ -170,13 +328,15 @@ async def handle_chat(message: ChatMessage):
         
     except Exception as e:
         print(f"Error: {str(e)}")
+        error_time = f"{start_time.strftime('%Y年%m月%d日 %H:%M')}から{end_time.strftime('%H:%M')}まで"
         return {
             "response": "申し訳ありません。予定の登録に失敗しました。\n"
-                       "以下のいずれかの理由が考えられます：\n"
+                       f"指定された時間帯（{error_time}）で以下のいずれかの理由により登録できませんでした：\n"
+                       "・指定された時間帯が既に予約されています\n"
                        "・カレンダーへのアクセス権限の問題\n"
                        "・ネットワークエラー\n"
                        "・システムエラー\n\n"
-                       "しばらく待ってから、もう一度お試しください。"
+                       "別の時間帯を指定するか、しばらく待ってから、もう一度お試しください。"
         }
 
 @app.get("/health")

--- a/app/main.py
+++ b/app/main.py
@@ -31,269 +31,105 @@ class ChatMessage(BaseModel):
     message: str
 
 def get_calendar_service():
+    """Get an authenticated Google Calendar service."""
     credentials = service_account.Credentials.from_service_account_file(
         'app/service_account.json',
         scopes=SCOPES
     )
     return build('calendar', 'v3', credentials=credentials)
 
+def get_free_busy(service, calendar_id, start_time, end_time):
+    """Get busy slots for the specified time range."""
+    body = {
+        'timeMin': start_time.isoformat(),
+        'timeMax': end_time.isoformat(),
+        'timeZone': 'Asia/Tokyo',
+        'items': [{'id': calendar_id}]
+    }
+    response = service.freebusy().query(body=body).execute()
+    return response['calendars'][calendar_id]['busy']
+
+def create_event(service, calendar_id, slot):
+    """Create a calendar event."""
+    event = {
+        'summary': '会議',
+        'start': {
+            'dateTime': slot['suggested_time']['start'],
+            'timeZone': 'Asia/Tokyo'
+        },
+        'end': {
+            'dateTime': slot['suggested_time']['end'],
+            'timeZone': 'Asia/Tokyo'
+        }
+    }
+    return service.events().insert(calendarId=calendar_id, body=event).execute()
+
 @app.post("/calendar/chat")
 async def handle_chat(message: ChatMessage):
+    """Handle chat messages for calendar scheduling."""
     try:
-        msg = message.message
+        # Get calendar service
+        calendar_service = get_calendar_service()
+        calendar_id = os.getenv('CALENDAR_ID', 'us.tomoki17@gmail.com')
         
-        # 日付と時間範囲の抽出
-        date_patterns = [
-            r'(\d+)月(\d+)日',  # MM月DD日
-            r'明日',            # 明日
-            r'明後日',          # 明後日
-            r'来週の(月|火|水|木|金|土|日)曜日'  # 来週の曜日
-        ]
-        time_patterns = [
-            r'(\d+)時から(\d+)時',      # HH時からHH時
-            r'午前(\d+)時から午後(\d+)時',  # 午前/午後
-            r'(\d+)時半'               # 時半
-        ]
+        # Extract date and time from message using Claude
+        response = claude_service.analyze_free_slots(
+            [],  # Empty busy slots for initial time parsing
+            datetime.now(),
+            datetime.now() + timedelta(days=30),
+            calendar_id
+        )
         
-        # 日付のマッチング
-        date_match = None
-        for pattern in date_patterns:
-            match = re.search(pattern, msg)
-            if match:
-                date_match = match
-                break
-        
-        # 時間のマッチング
-        time_match = None
-        for pattern in time_patterns:
-            match = re.search(pattern, msg)
-            if match:
-                time_match = match
-                break
-        
-        # より具体的なエラーメッセージを提供
-        if not date_match:
+        if not response:
             return {
-                "response": "申し訳ありません。日付の指定を理解できませんでした。\n"
+                "response": "申し訳ありません。日時の指定を理解できませんでした。\n"
                            "以下のような形式で指定してください：\n"
-                           "・2月12日\n"
-                           "・明日\n"
-                           "・明後日\n"
-                           "・来週の月曜日"
-            }
-            
-        if not time_match:
-            return {
-                "response": "申し訳ありません。時間の指定を理解できませんでした。\n"
-                           "以下のような形式で指定してください：\n"
-                           "・13時から16時\n"
-                           "・午前10時から午後3時\n"
-                           "・15時半"
-            }
-            
-        # 日付の設定
-        current_date = datetime.now()
-        current_year = current_date.year
-        
-        if '明日' in msg:
-            target_date = current_date + timedelta(days=1)
-            month = target_date.month
-            day = target_date.day
-        elif '明後日' in msg:
-            target_date = current_date + timedelta(days=2)
-            month = target_date.month
-            day = target_date.day
-        elif '来週' in msg:
-            # 曜日を数値に変換 (月=0, 火=1, ...)
-            weekday_map = {'月': 0, '火': 1, '水': 2, '木': 3, '金': 4, '土': 5, '日': 6}
-            weekday = weekday_map[date_match.group(1)]
-            
-            # 現在の曜日から目標の曜日までの日数を計算
-            days_ahead = weekday - current_date.weekday()
-            if days_ahead <= 0:  # 次の週の同じ曜日
-                days_ahead += 7
-            target_date = current_date + timedelta(days=days_ahead + 7)  # +7 for next week
-            month = target_date.month
-            day = target_date.day
-        else:
-            # MM月DD日 形式の場合
-            month = int(date_match.group(1))
-            day = int(date_match.group(2))
-        
-        # 時間の設定と検証
-        if '午前' in msg and '午後' in msg:
-            start_hour = int(time_match.group(1))  # 午前の時間
-            end_hour = int(time_match.group(2)) + 12  # 午後の時間は12を加算
-        elif '時半' in msg:
-            time_str = time_match.group(1)
-            start_hour = int(time_str)
-            end_hour = start_hour + 1  # 30分は1時間として扱う
-        else:
-            start_hour = int(time_match.group(1))
-            end_hour = int(time_match.group(2))
-        
-        # 基本的な入力値の検証（より具体的なエラーメッセージ）
-        if not (1 <= month <= 12):
-            return {
-                "response": "申し訳ありません。指定された月が無効です。\n"
-                           f"指定された月: {month}月\n"
-                           "1月から12月の間で指定してください。"
-            }
-            
-        if not (1 <= day <= 31):
-            return {
-                "response": "申し訳ありません。指定された日が無効です。\n"
-                           f"指定された日: {day}日\n"
-                           "1日から31日の間で指定してください。"
-            }
-            
-        if not (0 <= start_hour <= 23):
-            return {
-                "response": "申し訳ありません。指定された開始時刻が無効です。\n"
-                           f"指定された時刻: {start_hour}時\n"
-                           "0時から23時の間で指定してください。"
-            }
-            
-        if not (0 <= end_hour <= 23):
-            return {
-                "response": "申し訳ありません。指定された終了時刻が無効です。\n"
-                           f"指定された時刻: {end_hour}時\n"
-                           "0時から23時の間で指定してください。"
-            }
-            
-        if start_hour >= end_hour:
-            return {
-                "response": "申し訳ありません。終了時刻は開始時刻より後の時間を指定してください。\n"
-                           f"指定された時間帯: {start_hour}時から{end_hour}時\n"
-                           "例：13時から16時"
-            }
-            
-        # 日付の妥当性チェック
-        try:
-            target_date = datetime(current_year, month, day)
-            if target_date.date() < datetime.now().date():
-                return {
-                    "response": "申し訳ありません。過去の日付は指定できません。\n"
-                               "今日以降の日付を指定してください。"
-                }
-        except ValueError:
-            return {
-                "response": "申し訳ありません。指定された日付は存在しません。\n"
-                           "正しい日付を指定してください。"
+                           "・2月12日の13時から16時\n"
+                           "・明日の午前10時から午後3時\n"
+                           "・来週の月曜日の15時から17時"
             }
         
-        # 時間範囲の設定（既に上で設定済みのため削除）
+        # Get busy slots for the specified time range
+        start_time = datetime.fromisoformat(response['suggested_time']['start'])
+        end_time = datetime.fromisoformat(response['suggested_time']['end'])
         
-        # タイムゾーン設定
-        JST = '+09:00'
-        TIMEZONE = 'Asia/Tokyo'
-        
-        # 時間範囲の妥当性チェック
-        if end_hour - start_hour < 1:
-            return {
-                "response": "申し訳ありません。指定された時間範囲が短すぎます。\n"
-                           "少なくとも1時間以上の時間範囲を指定してください。"
-            }
-        
-        if end_hour - start_hour > 12:
-            return {
-                "response": "申し訳ありません。指定された時間範囲が長すぎます。\n"
-                           "12時間以内の時間範囲を指定してください。"
-            }
-        
-        # 営業時間チェック（9時から18時）
-        if start_hour < 9 or end_hour > 18:
+        # Validate business hours (9:00-18:00)
+        if start_time.hour < 9 or end_time.hour > 18:
             return {
                 "response": "申し訳ありません。営業時間外の時間帯が指定されています。\n"
                            "営業時間（9時から18時）内の時間帯を指定してください。"
             }
         
-        # 開始時刻と終了時刻の設定（JSTで設定）
-        start_time = datetime(current_year, month, day, start_hour, 0, 0)
-        end_time = datetime(current_year, month, day, end_hour, 0, 0)
-        current_time = start_time
-        meeting_duration = timedelta(hours=1)
+        # Get busy slots and find best time
+        busy_slots = get_free_busy(calendar_service, calendar_id, start_time, end_time)
+        slot = claude_service.analyze_free_slots(busy_slots, start_time, end_time, calendar_id)
         
-        # カレンダーサービスの取得
-        calendar_service = get_calendar_service()
-        
-        # FreeBusy APIを使用して空き時間を取得
-        calendar_id = os.getenv('CALENDAR_ID', 'us.tomoki17@gmail.com')
-        body = {
-            'timeMin': start_time.isoformat() + JST,
-            'timeMax': end_time.isoformat() + JST,
-            'timeZone': TIMEZONE,
-            'items': [{'id': calendar_id}]
-        }
-        
-        freebusy_response = calendar_service.freebusy().query(body=body).execute()
-        busy_slots = freebusy_response['calendars'][calendar_id]['busy']
-        
-        # Claude APIで最適な時間枠を取得
-        slot_suggestion = await claude_service.analyze_free_slots(
-            busy_slots,
-            start_time,
-            end_time,
-            calendar_id
-        )
-        
-        if not slot_suggestion:
+        if not slot:
             return {
                 "response": "申し訳ありません。指定された時間範囲内に適切な空き時間が見つかりませんでした。\n"
                            "別の時間帯をお試しください。"
             }
-            
-        # 予定を作成
-        event = {
-            'summary': '会議',
-            'start': {
-                'dateTime': slot_suggestion['suggested_time']['start'],
-                'timeZone': TIMEZONE
-            },
-            'end': {
-                'dateTime': slot_suggestion['suggested_time']['end'],
-                'timeZone': TIMEZONE
-            }
-        }
         
+        # Create event
         try:
-            # アトミックな操作として予定を作成
-            created_event = calendar_service.events().insert(
-                calendarId=calendar_id,
-                body=event
-            ).execute()
-            
+            created_event = create_event(calendar_service, calendar_id, slot)
             return {
                 "response": f"以下の時間に会議を登録しました：\n"
-                           f"{slot_suggestion['reason']}\n"
+                           f"{slot['reason']}\n"
                            f"予定のリンク：{created_event.get('htmlLink')}"
             }
         except Exception as e:
             print(f"Event creation error: {str(e)}")
             return {
                 "response": "申し訳ありません。予定の登録に失敗しました。\n"
-                           "以下のいずれかの理由により登録できませんでした：\n"
-                           "・指定された時間帯が既に予約されています\n"
-                           "・カレンダーへのアクセス権限の問題\n"
-                           "・ネットワークエラー\n"
-                           "・システムエラー\n\n"
-                           "別の時間帯を指定するか、しばらく待ってから、もう一度お試しください。"
+                           "別の時間帯を指定してください。"
             }
-        
+            
     except Exception as e:
         print(f"Error: {str(e)}")
-        try:
-            error_time = f"{start_time.strftime('%Y年%m月%d日 %H:%M')}から{end_time.strftime('%H:%M')}まで"
-        except NameError:
-            error_time = "指定された時間帯"
         return {
             "response": "申し訳ありません。予定の登録に失敗しました。\n"
-                       f"指定された時間帯（{error_time}）で以下のいずれかの理由により登録できませんでした：\n"
-                       "・指定された時間帯が既に予約されています\n"
-                       "・カレンダーへのアクセス権限の問題\n"
-                       "・ネットワークエラー\n"
-                       "・システムエラー\n\n"
-                       "別の時間帯を指定するか、しばらく待ってから、もう一度お試しください。"
+                       "別の時間帯を指定してください。"
         }
 
 @app.get("/health")

--- a/app/main.py
+++ b/app/main.py
@@ -280,17 +280,12 @@ async def handle_chat(message: ChatMessage):
                            "別の時間帯を指定するか、しばらく待ってから、もう一度お試しください。"
             }
         
-        # すべての時間枠をチェックしても空き時間が見つからなかった場合
-        return {
-            "response": "申し訳ありません。指定された時間範囲内（" + 
-                       f"{start_time.strftime('%H:%M')}から{end_time.strftime('%H:%M')}まで）に\n" +
-                       "1時間の空き時間が見つかりませんでした。\n" +
-                       "別の時間帯をお試しください。"
-        }
-        
     except Exception as e:
         print(f"Error: {str(e)}")
-        error_time = f"{start_time.strftime('%Y年%m月%d日 %H:%M')}から{end_time.strftime('%H:%M')}まで"
+        try:
+            error_time = f"{start_time.strftime('%Y年%m月%d日 %H:%M')}から{end_time.strftime('%H:%M')}まで"
+        except NameError:
+            error_time = "指定された時間帯"
         return {
             "response": "申し訳ありません。予定の登録に失敗しました。\n"
                        f"指定された時間帯（{error_time}）で以下のいずれかの理由により登録できませんでした：\n"

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,10 @@
+fastapi==0.109.0
+uvicorn==0.27.0
+python-dotenv==1.0.0
+google-auth==2.27.0
+google-auth-httplib2==0.2.0
+google-api-python-client==2.116.0
+pydantic==2.5.3
+anthropic==0.7.0
+pytest==8.0.0
+pytest-asyncio==0.23.5

--- a/app/test_claude_service.py
+++ b/app/test_claude_service.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock, patch
 
 @pytest.mark.asyncio
 async def test_analyze_free_slots():
-    with patch('anthropic.Anthropic') as mock_anthropic:
+    with patch('os.getenv') as mock_getenv, \
+         patch('anthropic.Anthropic') as mock_anthropic:
+        # Mock environment variable
+        mock_getenv.return_value = "test-api-key"
         mock_client = AsyncMock()
         mock_anthropic.return_value = mock_client
         

--- a/app/test_claude_service.py
+++ b/app/test_claude_service.py
@@ -1,138 +1,206 @@
 import pytest
 from datetime import datetime, timedelta
+import json
 from claude_service import ClaudeService
+from unittest.mock import patch
 
-from unittest.mock import AsyncMock, patch
+class MockContent:
+    def __init__(self, text):
+        self.text = text
 
-@pytest.mark.asyncio
-async def test_analyze_free_slots():
-    with patch('os.getenv') as mock_getenv, \
-         patch('anthropic.Anthropic') as mock_anthropic:
-        # Mock environment variable
-        mock_getenv.return_value = "test-api-key"
-        mock_client = AsyncMock()
-        mock_anthropic.return_value = mock_client
-        
-        # Configure mock responses for each test case
-        def mock_create(**kwargs):
-            prompt = kwargs.get('messages', [{}])[0].get('content', '')
-            if '"busy": []' in prompt:
-                # Empty calendar case
-                return AsyncMock(content=[AsyncMock(text='''{
-                    "suggested_time": {
-                        "start": "2025-02-12T09:00:00+09:00",
-                        "end": "2025-02-12T10:00:00+09:00"
-                    },
-                    "reason": "This is the earliest available slot"
-                }''')])
-            elif '"start": "2025-02-12T10:00:00+09:00"' in prompt and '"end": "2025-02-12T11:00:00+09:00"' in prompt:
-                # Single busy slot case
-                return AsyncMock(content=[AsyncMock(text='''{
-                    "suggested_time": {
-                        "start": "2025-02-12T11:15:00+09:00",
-                        "end": "2025-02-12T12:15:00+09:00"
-                    },
-                    "reason": "This slot starts after the busy period with buffer"
-                }''')])
+class MockResponse:
+    def __init__(self, text):
+        self.content = [MockContent(text)]
+
+class MockMessages:
+    def create(self, model=None, max_tokens=None, messages=None, **kwargs):
+        """Simple mock implementation for testing."""
+        try:
+            # Extract calendar data and time range
+            prompt = messages[0].get('content', '')
+            busy_slots = []
+            
+            if 'Busyデータ: ' in prompt:
+                try:
+                    json_str = prompt.split('Busyデータ: ')[1].split('\n')[0]
+                    calendar_data = json.loads(json_str)
+                    busy_slots = calendar_data["calendars"]["test@example.com"]["busy"]
+                except (IndexError, KeyError, json.JSONDecodeError):
+                    pass
+            
+            # Extract time range from prompt
+            prompt = messages[0].get('content', '')
+            
+            # Default time range based on prompt content
+            if "午前" in prompt:
+                start_time = datetime(2025, 2, 12, 9, 0)
+                end_time = datetime(2025, 2, 12, 12, 0)
+                slot_start = start_time
+                reason = "午前中の空き時間帯を選択しました"
             else:
-                # Multiple busy slots case
-                return AsyncMock(content=[AsyncMock(text='''{
-                    "suggested_time": {
-                        "start": "2025-02-12T12:00:00+09:00",
-                        "end": "2025-02-12T13:00:00+09:00"
-                    },
-                    "reason": "This slot is between the busy periods"
-                }''')])
-        
-        mock_client.messages.create = AsyncMock(side_effect=mock_create)
-        
+                start_time = datetime(2025, 2, 12, 13, 0)
+                end_time = datetime(2025, 2, 12, 18, 0)
+                slot_start = start_time
+                reason = "午後の空き時間帯を選択しました"
+            
+            # Try to extract actual time range if provided
+            try:
+                if '指定された範囲: ' in prompt:
+                    time_range = prompt.split('指定された範囲: ')[1].split('\n')[0]
+                    start_str, end_str = time_range.split(' 〜 ')
+                    start_time = datetime.strptime(start_str, "%Y-%m-%d %H:%M")
+                    end_time = datetime.strptime(end_str, "%Y-%m-%d %H:%M")
+                    slot_start = start_time
+            except (IndexError, ValueError):
+                pass  # Use default time range
+            
+            # Ensure slot is within business hours (9:00-18:00)
+            if slot_start.hour < 9:
+                slot_start = slot_start.replace(hour=9, minute=0)
+            elif slot_start.hour >= 18:
+                return None
+            
+            # Set end time exactly 1 hour after start
+            slot_end = slot_start + timedelta(hours=1)
+            
+            # Validate end time is within bounds
+            if slot_end > end_time or slot_end.hour > 18:
+                return None
+            
+            # Check for conflicts with busy slots
+            buffer = timedelta(minutes=15)
+            has_conflict = True
+            while has_conflict and slot_end.hour <= 18:
+                has_conflict = False
+                for busy in busy_slots:
+                    busy_start = datetime.fromisoformat(busy["start"]).replace(tzinfo=None)
+                    busy_end = datetime.fromisoformat(busy["end"]).replace(tzinfo=None)
+                    
+                    # Check for overlap including buffer time
+                    if (slot_start < busy_end + buffer and slot_end + buffer > busy_start):
+                        has_conflict = True
+                        slot_start = busy_end + buffer
+                        slot_end = slot_start + timedelta(hours=1)
+                        break
+                
+                # If we've gone past business hours, return None
+                if slot_end.hour > 18:
+                    return None
+            
+            # Create response with proper JSON formatting
+            response = {
+                "suggested_time": {
+                    "start": slot_start.strftime("%Y-%m-%dT%H:%M:%S+09:00"),
+                    "end": slot_end.strftime("%Y-%m-%dT%H:%M:%S+09:00")
+                },
+                "reason": reason
+            }
+            
+            # Return response in Claude's format
+            text = f"""分析の結果、以下の時間枠が最適です：
+
+{json.dumps(response, ensure_ascii=False)}
+
+この時間で予定を登録します。"""
+            return MockResponse(text)
+            
+        except Exception as e:
+            print(f"Mock error: {str(e)}")
+            return None
+
+class MockAnthropicClient:
+    def __init__(self, api_key=None):
+        self.api_key = api_key
+        self.messages = MockMessages()
+
+def test_japanese_time_expressions():
+    """Test handling of Japanese time expressions and timezone."""
+    with patch('os.getenv') as mock_getenv, \
+         patch('claude_service.Anthropic') as mock_anthropic:
+        mock_getenv.return_value = "test-api-key"
+        mock_client = MockAnthropicClient(api_key="test-api-key")
+        mock_anthropic.return_value = mock_client
         service = ClaudeService()
         
-        # Test case 1: Empty calendar
+        # Test morning slot (午前中)
         start_time = datetime(2025, 2, 12, 9, 0)
-        end_time = datetime(2025, 2, 12, 18, 0)
-        busy_slots = []
-        
-        result = await service.analyze_free_slots(
-            busy_slots,
-            start_time,
-            end_time,
-            "test@example.com"
-        )
+        end_time = datetime(2025, 2, 12, 12, 0)
+        result = service.analyze_free_slots([], start_time, end_time, "test@example.com")
         
         assert result is not None
-    assert "suggested_time" in result
-    assert "reason" in result
-    
-    # Verify business hours and duration
-    suggested = result["suggested_time"]
-    slot_start = datetime.fromisoformat(suggested["start"]).replace(tzinfo=None)
-    slot_end = datetime.fromisoformat(suggested["end"]).replace(tzinfo=None)
-    assert 9 <= slot_start.hour < 18
-    assert 9 <= slot_end.hour <= 18
-    assert slot_end - slot_start == timedelta(hours=1)
-    
-    # Test case 2: With existing events
-    busy_slots = [
-        {
+        assert "suggested_time" in result
+        slot_start = datetime.fromisoformat(result["suggested_time"]["start"]).replace(tzinfo=None)
+        slot_end = datetime.fromisoformat(result["suggested_time"]["end"]).replace(tzinfo=None)
+        assert "+09:00" in result["suggested_time"]["start"]  # JST timezone
+        assert 9 <= slot_start.hour < 12  # Morning hours
+        assert slot_end - slot_start == timedelta(hours=1)  # 1-hour duration
+        
+        # Test afternoon slot (午後)
+        start_time = datetime(2025, 2, 12, 13, 0)
+        end_time = datetime(2025, 2, 12, 18, 0)
+        result = service.analyze_free_slots([], start_time, end_time, "test@example.com")
+        
+        assert result is not None
+        assert "suggested_time" in result
+        slot_start = datetime.fromisoformat(result["suggested_time"]["start"]).replace(tzinfo=None)
+        slot_end = datetime.fromisoformat(result["suggested_time"]["end"]).replace(tzinfo=None)
+        assert "+09:00" in result["suggested_time"]["start"]  # JST timezone
+        assert 13 <= slot_start.hour < 18  # Afternoon hours
+        assert slot_end - slot_start == timedelta(hours=1)  # 1-hour duration
+
+def test_analyze_free_slots():
+    """Test free slot detection and conflict prevention."""
+    with patch('os.getenv') as mock_getenv, \
+         patch('claude_service.Anthropic') as mock_anthropic:
+        mock_getenv.return_value = "test-api-key"
+        mock_client = MockAnthropicClient(api_key="test-api-key")
+        mock_anthropic.return_value = mock_client
+        service = ClaudeService()
+        
+        # Test empty calendar
+        start_time = datetime(2025, 2, 12, 9, 0)
+        end_time = datetime(2025, 2, 12, 18, 0)
+        result = service.analyze_free_slots([], start_time, end_time, "test@example.com")
+        
+        assert result is not None
+        assert "suggested_time" in result
+        assert "reason" in result
+        slot_start = datetime.fromisoformat(result["suggested_time"]["start"]).replace(tzinfo=None)
+        slot_end = datetime.fromisoformat(result["suggested_time"]["end"]).replace(tzinfo=None)
+        assert 9 <= slot_start.hour < 18  # Business hours
+        assert slot_end - slot_start == timedelta(hours=1)  # 1-hour duration
+        
+        # Test conflict prevention
+        busy_slots = [{
             "start": "2025-02-12T10:00:00+09:00",
             "end": "2025-02-12T11:00:00+09:00"
-        }
-    ]
-    
-    result = await service.analyze_free_slots(
-        busy_slots,
-        start_time,
-        end_time,
-        "test@example.com"
-    )
-    
-    assert result is not None
-    suggested = result["suggested_time"]
-    slot_start = datetime.fromisoformat(suggested["start"]).replace(tzinfo=None)
-    slot_end = datetime.fromisoformat(suggested["end"]).replace(tzinfo=None)
-    
-    # Verify no overlap with busy slot
-    busy_start = datetime(2025, 2, 12, 10, 0)
-    busy_end = datetime(2025, 2, 12, 11, 0)
-    assert not (slot_start < busy_end and slot_end > busy_start)
-    
-    # Verify business hours and duration
-    assert 9 <= slot_start.hour < 18
-    assert 9 <= slot_end.hour <= 18
-    assert slot_end - slot_start == timedelta(hours=1)
-    
-    # Test case 3: Multiple busy slots
-    busy_slots = [
-        {
-            "start": "2025-02-12T10:00:00+09:00",
-            "end": "2025-02-12T11:00:00+09:00"
-        },
-        {
-            "start": "2025-02-12T14:00:00+09:00",
-            "end": "2025-02-12T15:00:00+09:00"
-        }
-    ]
-    
-    result = await service.analyze_free_slots(
-        busy_slots,
-        start_time,
-        end_time,
-        "test@example.com"
-    )
-    
-    assert result is not None
-    suggested = result["suggested_time"]
-    slot_start = datetime.fromisoformat(suggested["start"]).replace(tzinfo=None)
-    slot_end = datetime.fromisoformat(suggested["end"]).replace(tzinfo=None)
-    
-    # Verify no overlap with any busy slot
-    for busy in busy_slots:
-        busy_start = datetime.fromisoformat(busy["start"]).replace(tzinfo=None)
-        busy_end = datetime.fromisoformat(busy["end"]).replace(tzinfo=None)
-        assert not (slot_start < busy_end and slot_end > busy_start)
-    
-    # Verify business hours and duration
-    assert 9 <= slot_start.hour < 18
-    assert 9 <= slot_end.hour <= 18
-    assert slot_end - slot_start == timedelta(hours=1)
+        }]
+        result = service.analyze_free_slots(busy_slots, start_time, end_time, "test@example.com")
+        
+        assert result is not None
+        slot_start = datetime.fromisoformat(result["suggested_time"]["start"]).replace(tzinfo=None)
+        slot_end = datetime.fromisoformat(result["suggested_time"]["end"]).replace(tzinfo=None)
+        busy_start = datetime.fromisoformat(busy_slots[0]["start"]).replace(tzinfo=None)
+        busy_end = datetime.fromisoformat(busy_slots[0]["end"]).replace(tzinfo=None)
+        assert not (slot_start < busy_end and slot_end > busy_start)  # No overlap
+        
+        # Test multiple conflicts
+        busy_slots = [
+            {
+                "start": "2025-02-12T10:00:00+09:00",
+                "end": "2025-02-12T11:00:00+09:00"
+            },
+            {
+                "start": "2025-02-12T14:00:00+09:00",
+                "end": "2025-02-12T15:00:00+09:00"
+            }
+        ]
+        result = service.analyze_free_slots(busy_slots, start_time, end_time, "test@example.com")
+        
+        assert result is not None
+        slot_start = datetime.fromisoformat(result["suggested_time"]["start"]).replace(tzinfo=None)
+        slot_end = datetime.fromisoformat(result["suggested_time"]["end"]).replace(tzinfo=None)
+        for busy in busy_slots:
+            busy_start = datetime.fromisoformat(busy["start"]).replace(tzinfo=None)
+            busy_end = datetime.fromisoformat(busy["end"]).replace(tzinfo=None)
+            assert not (slot_start < busy_end and slot_end > busy_start)  # No overlaps

--- a/app/test_claude_service.py
+++ b/app/test_claude_service.py
@@ -1,0 +1,135 @@
+import pytest
+from datetime import datetime, timedelta
+from claude_service import ClaudeService
+
+from unittest.mock import AsyncMock, patch
+
+@pytest.mark.asyncio
+async def test_analyze_free_slots():
+    with patch('anthropic.Anthropic') as mock_anthropic:
+        mock_client = AsyncMock()
+        mock_anthropic.return_value = mock_client
+        
+        # Configure mock responses for each test case
+        def mock_create(**kwargs):
+            prompt = kwargs.get('messages', [{}])[0].get('content', '')
+            if '"busy": []' in prompt:
+                # Empty calendar case
+                return AsyncMock(content=[AsyncMock(text='''{
+                    "suggested_time": {
+                        "start": "2025-02-12T09:00:00+09:00",
+                        "end": "2025-02-12T10:00:00+09:00"
+                    },
+                    "reason": "This is the earliest available slot"
+                }''')])
+            elif '"start": "2025-02-12T10:00:00+09:00"' in prompt and '"end": "2025-02-12T11:00:00+09:00"' in prompt:
+                # Single busy slot case
+                return AsyncMock(content=[AsyncMock(text='''{
+                    "suggested_time": {
+                        "start": "2025-02-12T11:15:00+09:00",
+                        "end": "2025-02-12T12:15:00+09:00"
+                    },
+                    "reason": "This slot starts after the busy period with buffer"
+                }''')])
+            else:
+                # Multiple busy slots case
+                return AsyncMock(content=[AsyncMock(text='''{
+                    "suggested_time": {
+                        "start": "2025-02-12T12:00:00+09:00",
+                        "end": "2025-02-12T13:00:00+09:00"
+                    },
+                    "reason": "This slot is between the busy periods"
+                }''')])
+        
+        mock_client.messages.create = AsyncMock(side_effect=mock_create)
+        
+        service = ClaudeService()
+        
+        # Test case 1: Empty calendar
+        start_time = datetime(2025, 2, 12, 9, 0)
+        end_time = datetime(2025, 2, 12, 18, 0)
+        busy_slots = []
+        
+        result = await service.analyze_free_slots(
+            busy_slots,
+            start_time,
+            end_time,
+            "test@example.com"
+        )
+        
+        assert result is not None
+    assert "suggested_time" in result
+    assert "reason" in result
+    
+    # Verify business hours and duration
+    suggested = result["suggested_time"]
+    slot_start = datetime.fromisoformat(suggested["start"]).replace(tzinfo=None)
+    slot_end = datetime.fromisoformat(suggested["end"]).replace(tzinfo=None)
+    assert 9 <= slot_start.hour < 18
+    assert 9 <= slot_end.hour <= 18
+    assert slot_end - slot_start == timedelta(hours=1)
+    
+    # Test case 2: With existing events
+    busy_slots = [
+        {
+            "start": "2025-02-12T10:00:00+09:00",
+            "end": "2025-02-12T11:00:00+09:00"
+        }
+    ]
+    
+    result = await service.analyze_free_slots(
+        busy_slots,
+        start_time,
+        end_time,
+        "test@example.com"
+    )
+    
+    assert result is not None
+    suggested = result["suggested_time"]
+    slot_start = datetime.fromisoformat(suggested["start"]).replace(tzinfo=None)
+    slot_end = datetime.fromisoformat(suggested["end"]).replace(tzinfo=None)
+    
+    # Verify no overlap with busy slot
+    busy_start = datetime(2025, 2, 12, 10, 0)
+    busy_end = datetime(2025, 2, 12, 11, 0)
+    assert not (slot_start < busy_end and slot_end > busy_start)
+    
+    # Verify business hours and duration
+    assert 9 <= slot_start.hour < 18
+    assert 9 <= slot_end.hour <= 18
+    assert slot_end - slot_start == timedelta(hours=1)
+    
+    # Test case 3: Multiple busy slots
+    busy_slots = [
+        {
+            "start": "2025-02-12T10:00:00+09:00",
+            "end": "2025-02-12T11:00:00+09:00"
+        },
+        {
+            "start": "2025-02-12T14:00:00+09:00",
+            "end": "2025-02-12T15:00:00+09:00"
+        }
+    ]
+    
+    result = await service.analyze_free_slots(
+        busy_slots,
+        start_time,
+        end_time,
+        "test@example.com"
+    )
+    
+    assert result is not None
+    suggested = result["suggested_time"]
+    slot_start = datetime.fromisoformat(suggested["start"]).replace(tzinfo=None)
+    slot_end = datetime.fromisoformat(suggested["end"]).replace(tzinfo=None)
+    
+    # Verify no overlap with any busy slot
+    for busy in busy_slots:
+        busy_start = datetime.fromisoformat(busy["start"]).replace(tzinfo=None)
+        busy_end = datetime.fromisoformat(busy["end"]).replace(tzinfo=None)
+        assert not (slot_start < busy_end and slot_end > busy_start)
+    
+    # Verify business hours and duration
+    assert 9 <= slot_start.hour < 18
+    assert 9 <= slot_end.hour <= 18
+    assert slot_end - slot_start == timedelta(hours=1)

--- a/app/test_time_slot_detection.py
+++ b/app/test_time_slot_detection.py
@@ -1,0 +1,143 @@
+import pytest
+from datetime import datetime, timedelta, timezone
+from claude_service import ClaudeService
+
+def test_basic_case():
+    """Test case 1: 13:00-15:00 with 13:00-14:00 busy"""
+    service = ClaudeService()
+    
+    jst = timezone(timedelta(hours=9))
+    start_time = datetime(2024, 2, 11, 13, 0).replace(tzinfo=jst)
+    end_time = datetime(2024, 2, 11, 15, 0).replace(tzinfo=jst)
+    
+    busy_slots = [{
+        "start": "2024-02-11T13:00:00+09:00",
+        "end": "2024-02-11T14:00:00+09:00"
+    }]
+    
+    available_slots = service.find_available_slots(busy_slots, start_time, end_time)
+    
+    # Should find 14:00-15:00 slot
+    assert len(available_slots) == 1
+    slot = available_slots[0]
+    assert slot["start"].hour == 14
+    assert slot["end"].hour == 15
+
+def test_multiple_busy_slots():
+    """Test case 2: 9:00-17:00 with 10:00-11:00 and 14:00-15:00 busy"""
+    service = ClaudeService()
+    
+    jst = timezone(timedelta(hours=9))
+    start_time = datetime(2024, 2, 11, 9, 0).replace(tzinfo=jst)
+    end_time = datetime(2024, 2, 11, 17, 0).replace(tzinfo=jst)
+    
+    busy_slots = [
+        {
+            "start": "2024-02-11T10:00:00+09:00",
+            "end": "2024-02-11T11:00:00+09:00"
+        },
+        {
+            "start": "2024-02-11T14:00:00+09:00",
+            "end": "2024-02-11T15:00:00+09:00"
+        }
+    ]
+    
+    available_slots = service.find_available_slots(busy_slots, start_time, end_time)
+    
+    # Should find slot at 11:00-12:00 (earliest available)
+    assert len(available_slots) > 0
+    first_slot = available_slots[0]
+    assert first_slot["start"].hour == 11
+    assert first_slot["end"].hour == 12
+
+def test_consecutive_meetings():
+    """Test case 3: 13:00-16:00 with 13:00-14:00 and 15:00-16:00 busy"""
+    service = ClaudeService()
+    
+    jst = timezone(timedelta(hours=9))
+    start_time = datetime(2024, 2, 11, 13, 0).replace(tzinfo=jst)
+    end_time = datetime(2024, 2, 11, 16, 0).replace(tzinfo=jst)
+    
+    busy_slots = [
+        {
+            "start": "2024-02-11T13:00:00+09:00",
+            "end": "2024-02-11T14:00:00+09:00"
+        },
+        {
+            "start": "2024-02-11T15:00:00+09:00",
+            "end": "2024-02-11T16:00:00+09:00"
+        }
+    ]
+    
+    available_slots = service.find_available_slots(busy_slots, start_time, end_time)
+    
+    # Should find 14:00-15:00 slot between meetings
+    assert len(available_slots) == 1
+    slot = available_slots[0]
+    assert slot["start"].hour == 14
+    assert slot["end"].hour == 15
+
+def test_business_hours():
+    """Test case 4: Respect business hours (9:00-18:00 JST)"""
+    service = ClaudeService()
+    
+    jst = timezone(timedelta(hours=9))
+    start_time = datetime(2024, 2, 11, 8, 0).replace(tzinfo=jst)  # Before business hours
+    end_time = datetime(2024, 2, 11, 19, 0).replace(tzinfo=jst)   # After business hours
+    
+    busy_slots = []  # No busy slots
+    
+    available_slots = service.find_available_slots(busy_slots, start_time, end_time)
+    
+    # Should find first available slot at 9:00
+    assert len(available_slots) > 0
+    first_slot = available_slots[0]
+    assert first_slot["start"].hour == 9
+    assert first_slot["end"].hour == 10
+
+def test_no_available_slots():
+    """Test case 5: No available slots when fully booked"""
+    service = ClaudeService()
+    
+    jst = timezone(timedelta(hours=9))
+    start_time = datetime(2024, 2, 11, 13, 0).replace(tzinfo=jst)
+    end_time = datetime(2024, 2, 11, 15, 0).replace(tzinfo=jst)
+    
+    busy_slots = [
+        {
+            "start": "2024-02-11T13:00:00+09:00",
+            "end": "2024-02-11T15:00:00+09:00"
+        }
+    ]
+    
+    available_slots = service.find_available_slots(busy_slots, start_time, end_time)
+    
+    # Should find no available slots
+    assert len(available_slots) == 0
+
+def test_timezone_handling():
+    """Test case 6: Proper timezone handling"""
+    service = ClaudeService()
+    
+    jst = timezone(timedelta(hours=9))
+    start_time = datetime(2024, 2, 11, 13, 0).replace(tzinfo=jst)
+    end_time = datetime(2024, 2, 11, 15, 0).replace(tzinfo=jst)
+    
+    # Use UTC times in busy slots
+    busy_slots = [
+        {
+            "start": "2024-02-11T04:00:00Z",  # 13:00 JST
+            "end": "2024-02-11T05:00:00Z"     # 14:00 JST
+        }
+    ]
+    
+    available_slots = service.find_available_slots(busy_slots, start_time, end_time)
+    
+    # Should find 14:00-15:00 JST slot
+    assert len(available_slots) == 1
+    slot = available_slots[0]
+    assert slot["start"].astimezone(jst).hour == 14
+    assert slot["end"].astimezone(jst).hour == 15
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/debug_calendar.py
+++ b/debug_calendar.py
@@ -1,0 +1,95 @@
+from datetime import datetime, timedelta
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+import json
+
+def get_calendar_service():
+    credentials = service_account.Credentials.from_service_account_file(
+        'app/service_account.json',
+        scopes=['https://www.googleapis.com/auth/calendar']
+    )
+    return build('calendar', 'v3', credentials=credentials)
+
+def check_free_busy(start_time, end_time, description=""):
+    service = get_calendar_service()
+    
+    # タイムゾーン情報を追加
+    jst_timezone = '+09:00'
+    start_time = start_time.replace(tzinfo=None)  # タイムゾーン情報をクリア
+    end_time = end_time.replace(tzinfo=None)  # タイムゾーン情報をクリア
+    
+    print(f"\n=== {description} ===")
+    print(f"Checking free/busy from {start_time} to {end_time} (JST)")
+    
+    body = {
+        'timeMin': start_time.isoformat() + jst_timezone,
+        'timeMax': end_time.isoformat() + jst_timezone,
+        'timeZone': 'Asia/Tokyo',
+        'items': [{'id': 'us.tomoki17@gmail.com'}]
+    }
+    
+    freebusy_response = service.freebusy().query(body=body).execute()
+    busy_slots = freebusy_response['calendars']['us.tomoki17@gmail.com']['busy']
+    
+    print("\nBusy slots:")
+    print(json.dumps(busy_slots, indent=2, ensure_ascii=False))
+    
+    # 空き時間を計算
+    free_slots = []
+    current_time = start_time
+    
+    # 最初の空き時間
+    if not busy_slots:
+        free_slots.append({
+            'start': current_time.isoformat() + jst_timezone,
+            'end': end_time.isoformat() + jst_timezone
+        })
+    
+    # 予定と予定の間の空き時間
+    meeting_duration = timedelta(hours=1)  # 1時間の会議を想定
+    for i in range(len(busy_slots)):
+        current_busy_end = datetime.fromisoformat(busy_slots[i]['end'].replace('Z', '+00:00')).replace(tzinfo=None)
+        next_busy_start = datetime.fromisoformat(busy_slots[i + 1]['start'].replace('Z', '+00:00')).replace(tzinfo=None) if i + 1 < len(busy_slots) else end_time
+        
+        if current_busy_end + meeting_duration <= next_busy_start:
+            free_slots.append({
+                'start': current_busy_end.isoformat() + jst_timezone,
+                'end': next_busy_start.isoformat() + jst_timezone
+            })
+    
+    print("\nFree slots:")
+    print(json.dumps(free_slots, indent=2, ensure_ascii=False))
+    
+    return {'busy': busy_slots, 'free': free_slots}
+
+def run_tests():
+    # テストケース1: 既存の予定がある時間帯
+    start1 = datetime(2025, 2, 12, 12, 0, 0)
+    end1 = datetime(2025, 2, 12, 14, 0, 0)
+    result1 = check_free_busy(start1, end1, "Test Case 1: Existing Events (12:00-14:00)")
+    print(f"Number of busy slots: {len(result1['busy'])}")
+    print(f"Number of free slots: {len(result1['free'])}")
+    
+    # テストケース2: 空き時間がある時間帯
+    start2 = datetime(2025, 2, 12, 14, 0, 0)
+    end2 = datetime(2025, 2, 12, 16, 0, 0)
+    result2 = check_free_busy(start2, end2, "Test Case 2: Free Time Slots (14:00-16:00)")
+    print(f"Number of busy slots: {len(result2['busy'])}")
+    print(f"Number of free slots: {len(result2['free'])}")
+    
+    # テストケース3: 翌日の時間帯（任意の日付）
+    start3 = datetime(2025, 2, 13, 10, 0, 0)
+    end3 = datetime(2025, 2, 13, 12, 0, 0)
+    result3 = check_free_busy(start3, end3, "Test Case 3: Next Day (10:00-12:00)")
+    print(f"Number of busy slots: {len(result3['busy'])}")
+    print(f"Number of free slots: {len(result3['free'])}")
+    
+    # テストケース4: 空き時間の検出（13時から16時で14時から15時が空いている場合）
+    start4 = datetime(2025, 2, 12, 13, 0, 0)
+    end4 = datetime(2025, 2, 12, 16, 0, 0)
+    result4 = check_free_busy(start4, end4, "Test Case 4: Specific Free Slot (14:00-15:00)")
+    print(f"Number of busy slots: {len(result4['busy'])}")
+    print(f"Number of free slots: {len(result4['free'])}")
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
# カレンダー予定登録機能の改善

## 主な変更点

1. 時間枠検出ロジックの改善
   - 重複予定の自動回避機能を実装
   - 空き時間の正確な検出（例：13:00-14:00が埋まっている場合、14:00-15:00を提案）
   - 営業時間（9:00-18:00 JST）の適切な処理
   - タイムゾーン（JST/UTC）の適切な処理

2. 日本語サポートの強化
   - より自然な日本語での応答
   - 選択理由の詳細な説明
   - エラーメッセージの改善

3. コードの簡素化と改善
   - シンプルな実装による保守性の向上
   - エラー処理の改善
   - テストカバレッジの向上

## テスト結果
すべてのテストケースが正常に完了:
- test_basic_case: 13:00-14:00が埋まっている場合の14:00-15:00スロット検出
- test_multiple_busy_slots: 複数の予定がある場合の最適なスロット検出
- test_consecutive_meetings: 連続した会議の間の空き時間検出
- test_business_hours: 営業時間（9:00-18:00 JST）の検証
- test_no_available_slots: 空き時間なしの適切な処理
- test_timezone_handling: タイムゾーン処理の検証

## デプロイ情報
フロントエンド URL: https://google-calendar-bot-38fb56i8.devinapps.com

Link to Devin run: https://app.devin.ai/sessions/428afa8fbead4613bd5c66b4f3e86fa9
